### PR TITLE
Fixing favico with empty route response

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,12 @@ app.get('/', (req, res) => {
     res.send('Welcome to the SEENECTASK API');
 });
 
+/**
+ * Favicon Route
+ */
+app.get('/favicon.ico', (req, res) => res.status(204)); // Empty response for favicon
+
+
 
 const connectDB = async () => {
     try {


### PR DESCRIPTION
Added an empty route with 204 to show no content for the favicon to fix the log issue in vercel