### PR TITLE
Fix favicon issue in log

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,11 +14,14 @@ const signUp = require('./routes/signUp');
 */
 
 app.use((req, res, next) => {
-    if (req.originalUrl && req.originalUrl.split("/").pop() === 'favicon.ico') {
+    const urlParts = req.originalUrl.split("/");
+    const lastPart = urlParts.pop();
+    if (lastPart === 'favicon.ico' || lastPart === 'favicon.png') {
         return res.sendStatus(204);
     }
     return next();
 });
+
 
 
 app.use(express.json());


### PR DESCRIPTION
I hate seeing the error 404 on favicon.ico and favicon.png so I use middleware to catch them and render them a status code of 204 to show that it has no content.

This is a server so expect nothing like that